### PR TITLE
Fix #675 - Implement semantic autocomplete for 2FA fields to prevent Firefox interference

### DIFF
--- a/core/app/core/src/lib/views/2fa/components/2fa-check-modal/2fa-check-modal.component.html
+++ b/core/app/core/src/lib/views/2fa/components/2fa-check-modal/2fa-check-modal.component.html
@@ -39,7 +39,7 @@
                        id='auth_code'
                        type='text'
                        name='auth_code'
-                       autocomplete='off'
+                       autocomplete='one-time-code'
                        class='mb-3 auth-input'/>
 
                 <scrm-button id='submit-2fa-code'

--- a/core/app/core/src/lib/views/2fa/components/2fa-check/2fa-check.component.html
+++ b/core/app/core/src/lib/views/2fa/components/2fa-check/2fa-check.component.html
@@ -30,7 +30,7 @@
     <input [(ngModel)]="authCode"
            id='auth_code'
            type='text'
-           autocomplete='off'
+           autocomplete='one-time-code'
            name='auth_code'
            class='mb-2 mt-2 pl-0'>
 

--- a/core/app/core/src/lib/views/2fa/components/2fa/2fa.component.html
+++ b/core/app/core/src/lib/views/2fa/components/2fa/2fa.component.html
@@ -111,7 +111,7 @@
                                                        id='auth_code'
                                                        type='text'
                                                        name='auth_code'
-                                                       autocomplete='off'
+                                                       autocomplete='one-time-code'
                                                        class='mb-3 auth-input'/>
 
                                                 <scrm-button id='submit-2fa-code'

--- a/core/app/core/src/lib/views/login/components/login/login.component.html
+++ b/core/app/core/src/lib/views/login/components/login/login.component.html
@@ -71,6 +71,7 @@
                            #username="ngModel"
                            placeholder="{{vm.appStrings['LBL_USER_NAME']}}"
                            aria-label="Username"
+                           autocomplete="username"
                            required>
                     <div *ngIf="username.invalid && username.touched" class="invalid-feedback">
                         {{vm.appStrings['ERR_MISSING_REQUIRED_FIELDS']}}
@@ -86,6 +87,7 @@
                            #password="ngModel"
                            placeholder="{{vm.appStrings['LBL_PASSWORD']}}"
                            aria-label="Password"
+                           autocomplete="current-password"
                            required>
                     <div *ngIf="password.invalid && password.touched" class="invalid-feedback">
                         {{vm.appStrings['ERR_MISSING_REQUIRED_FIELDS']}}
@@ -119,6 +121,7 @@
                            #username="ngModel"
                            placeholder="{{vm.appStrings['LBL_USER_NAME']}}"
                            aria-label="Username"
+                           autocomplete="username"
                            required>
                     <div *ngIf="username.invalid && username.touched" class="invalid-feedback">
                         {{vm.appStrings['ERR_MISSING_REQUIRED_FIELDS']}}
@@ -134,6 +137,7 @@
                            #mail="ngModel"
                            placeholder="{{vm.appStrings['LBL_EMAIL']}}"
                            aria-label="Email"
+                           autocomplete="email"
                            required>
                     <div *ngIf="mail.invalid && mail.touched" class="invalid-feedback">
                         {{vm.appStrings['ERR_MISSING_REQUIRED_FIELDS']}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

Resolves Firefox password manager interference with 2FA input fields by implementing semantic autocomplete attributes.

**Problem**: Firefox was autofilling 2FA fields with saved passwords, hiding login buttons and requiring users to click elsewhere before proceeding.

**Root Cause**: Firefox intentionally ignores `autocomplete="off"` for login-related fields as a security feature to promote password manager usage.

**Solution**: Replaced generic `autocomplete="off"` with semantic `autocomplete="one-time-code"` for all 2FA components, which provides proper browser guidance without fighting browser behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Users experienced UI interference when Firefox's password manager would autofill 2FA verification fields with saved passwords, obscuring the login button and disrupting the authentication flow.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. **Firefox with saved passwords**: Navigate to 2FA setup at `/#/users/2fa-config`
2. Enable 2FA and generate QR code
3. Enter 6-digit authenticator code in verification field
4. **Expected**: Field remains empty until user types, no password autofill interference
5. **Expected**: Submit button remains visible and functional

**Additional Test**: Complete login flow with 2FA verification - should have smooth UX without button hiding.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->