### PR TITLE
Fix #691 - System name not updating in system settings

### DIFF
--- a/public/legacy/modules/Administration/Administration.php
+++ b/public/legacy/modules/Administration/Administration.php
@@ -185,7 +185,9 @@ class Administration extends SugarBean
         // outbound email settings
         $oe = new OutboundEmail();
 
-        foreach ($_GET as $key => $val) {
+        $request = array_merge($_GET, $_POST);
+
+        foreach ($request as $key => $val) {
             $prefix = $this->get_config_prefix($key);
             if (in_array($prefix[0], $this->config_categories)) {
                 if (is_array($val)) {


### PR DESCRIPTION
## Description
Page inputs in 'system settings', including 'system name', are sent via post request but do not get saved as only $_GET variables are included. A variable merging $_POST and $_GET replaces $_GET when looking for values after saving the system settings. Please see the following issue:

https://github.com/SuiteCRM/SuiteCRM-Core/issues/691

## Motivation and Context
As both $_GET and $_POST variables need to be read here from different parts of the system, combining both arrays into a new variable will fix the issue.

## How To Test This
'admin' -> 'system settings'

Change the system name and save

System name should be changed when going back into system settings

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.