### PR TITLE
Fix V8 API rejecting bean aliases in the module access check

### DIFF
--- a/public/legacy/Api/V8/BeanDecorator/BeanManager.php
+++ b/public/legacy/Api/V8/BeanDecorator/BeanManager.php
@@ -32,6 +32,29 @@ class BeanManager
     }
 
     /**
+     * Resolves a bean alias, e.g. 'Contracts', to the real module name, e.g. 'AOS_Contracts'.
+     *
+     * A name that already belongs to a real module is returned untouched, so an alias can
+     * never shadow an existing module.
+     *
+     * @param string $module
+     *
+     * @return string
+     */
+    public function resolveModuleAlias($module)
+    {
+        if (\BeanFactory::getObjectName($module)) {
+            return $module;
+        }
+
+        if (array_key_exists($module, $this->beanAliases)) {
+            return $this->beanAliases[$module];
+        }
+
+        return $module;
+    }
+
+    /**
      * @param string $module
      *
      * @return \SugarBean

--- a/public/legacy/Api/V8/Config/services/helpers.php
+++ b/public/legacy/Api/V8/Config/services/helpers.php
@@ -28,6 +28,8 @@ return CustomLoader::mergeCustomArray([
         return new Helper\ModuleListProvider();
     },
     Helper\ModuleAccessChecker::class => function (Container $container) {
-        return new Helper\ModuleAccessChecker();
+        return new Helper\ModuleAccessChecker(
+            $container->get(BeanManager::class)
+        );
     },
 ], basename(__FILE__));

--- a/public/legacy/Api/V8/Helper/ModuleAccessChecker.php
+++ b/public/legacy/Api/V8/Helper/ModuleAccessChecker.php
@@ -28,6 +28,7 @@
 namespace Api\V8\Helper;
 
 use ACLController;
+use Api\V8\BeanDecorator\BeanManager;
 use SuiteCRM\Exception\NotAllowedException;
 
 /**
@@ -38,12 +39,29 @@ use SuiteCRM\Exception\NotAllowedException;
 class ModuleAccessChecker
 {
     /**
+     * @var BeanManager
+     */
+    private $beanManager;
+
+    /**
+     * @param BeanManager $beanManager
+     */
+    public function __construct(BeanManager $beanManager)
+    {
+        $this->beanManager = $beanManager;
+    }
+
+    /**
      * @param string $module
      * @throws NotAllowedException
      */
     public function checkAccess(string $module): void
     {
         global $current_user, $adminOnlyList;
+
+        // The rest of the API accepts bean aliases, e.g. 'Contracts' for 'AOS_Contracts', so
+        // resolve before matching: the lists checked below only ever hold real module names.
+        $module = $this->beanManager->resolveModuleAlias($module);
 
         // not in $moduleList, so the tab check below would reject it for everyone; row/field-level
         // enforcement happens in ModuleService instead

--- a/public/legacy/Api/V8/Service/ModuleService.php
+++ b/public/legacy/Api/V8/Service/ModuleService.php
@@ -74,13 +74,14 @@ class ModuleService
     public function getRecord(GetModuleParams $params, $path)
     {
         $fields = $params->getFields();
+        $module = $this->beanManager->resolveModuleAlias($params->getModuleName());
         $bean = $this->beanManager->getBeanSafe(
-            $params->getModuleName(),
+            $module,
             $params->getId()
         );
 
-        $this->assertSelfOrAdmin($params->getModuleName(), $bean->id);
-        if ($params->getModuleName() === 'Employees' && !isTrue($bean->show_on_employees)) {
+        $this->assertSelfOrAdmin($module, $bean->id);
+        if ($module === 'Employees' && !isTrue($bean->show_on_employees)) {
             throw new AccessDeniedException();
         }
 
@@ -107,7 +108,7 @@ class ModuleService
         $beanResult = [];
         global $db, $current_user;
         // this whole method should split into separated classes later
-        $module = $params->getModuleName();
+        $module = $this->beanManager->resolveModuleAlias($params->getModuleName());
 
         $orderBy = $params->getSort();
         $where = $params->getFilter();
@@ -261,7 +262,7 @@ class ModuleService
      */
     public function createRecord(CreateModuleParams $params, Request $request)
     {
-        $module = $params->getData()->getType();
+        $module = $this->beanManager->resolveModuleAlias($params->getData()->getType());
         $id = $params->getData()->getId();
         $attributes = $params->getData()->getAttributes();
 
@@ -441,7 +442,7 @@ class ModuleService
      */
     public function updateRecord(UpdateModuleParams $params, Request $request)
     {
-        $module = $params->getData()->getType();
+        $module = $this->beanManager->resolveModuleAlias($params->getData()->getType());
         $id = $params->getData()->getId();
         $attributes = $params->getData()->getAttributes();
         unset(
@@ -540,14 +541,16 @@ class ModuleService
      */
     public function deleteRecord(DeleteModuleParams $params)
     {
-        $this->assertAdmin($params->getModuleName());
+        $module = $this->beanManager->resolveModuleAlias($params->getModuleName());
+
+        $this->assertAdmin($module);
 
         $bean = $this->beanManager->getBeanSafe(
-            $params->getModuleName(),
+            $module,
             $params->getId()
         );
 
-        $this->assertNotSelf($params->getModuleName(), $bean->id);
+        $this->assertNotSelf($module, $bean->id);
 
         if (!$bean->ACLAccess('delete')) {
             throw new AccessDeniedException();


### PR DESCRIPTION
## Description

Since 8.10.2 the V8 API rejects every module name that is a **bean alias** rather than a real
module name. `GET /Api/V8/module/AOS_Contracts` works, `GET /Api/V8/module/Contracts` does not:

```json
{
    "errors": {
        "status": 400,
        "detail": "[SuiteCRM] [Not Allowed] The API user does not have access to this module."
    }
}
```

This happens **even when authenticated as an admin**, so the error message is misleading: nothing
is wrong with the user's access, the module name simply never gets resolved.

Affected names are all the keys of `Api/V8/Config/services/beanAliases.php`, i.e. `Contracts`,
`Quotes`, `Invoices`, `ProductQuotes`, and the singular object names such as `Account`, `Contact`,
`Case`, `Opportunity`, `Lead`, `Document`, `Note`, `Task`. Every module endpoint is affected, since
all eleven `*Params` classes implement the new `ModuleAwareParamInterface`: get/create/update/delete
record, relationships, field list and list view.

### Root cause

`ParamsMiddleware` calls the new access check with the raw name taken from the request:

```php
if ($this->params instanceof ModuleAwareParamInterface) {
    $this->moduleAccessChecker->checkAccess($this->params->getModuleName());
}
```

and `ModuleAccessChecker::checkAccess()` matches that name against the tab list:

```php
$modules = query_module_access_list($current_user);
ACLController::filterModuleList($modules, false);

if (!in_array($module, $modules, true)) {
    throw new NotAllowedException('The API user does not have access to this module.');
}
```

`query_module_access_list()` only ever returns real module names, so an alias can never match.
`Contracts` in particular is merely the *display label* of `AOS_Contracts`
(`$app_list_strings['moduleList']['AOS_Contracts'] = 'Contracts'`), and `BeanFactory::newBean('Contracts')`
returns `false`.

Aliases are resolved much further down the stack, in `BeanManager::newBeanSafe()` / `getBeanSafe()` —
downstream of the new gate. So the alias layer that exists precisely to accept these names is
never reached.

### The fix

Resolve the alias in `ModuleAccessChecker` before matching, through a new
`BeanManager::resolveModuleAlias()`. The same ACL check then runs against the canonical module
name, so access control is unchanged — only the name lookup is fixed.

A name that already belongs to a real module is returned untouched, so an alias can never shadow
an existing module. Unknown names are passed through and still rejected by the gate.

`ParamsMiddleware` is left untouched: resolving inside the checker keeps the gate self-sufficient,
so any future caller of `checkAccess()` gets the same answer as the rest of the API.

### Why `ModuleService` is part of this PR

`ModuleService` enforces the Users/Employees restrictions added in the same release with strict
comparisons on the **raw** requested name:

```php
private function assertSelfOrAdmin(string $module, string $id): void
{
    if ($module === 'Users' && !$current_user->isAdmin() && $id !== $current_user->id) {
        throw new AccessDeniedException();
    }
}
```

In stock 8.10.2 that is not reachable, because `checkAccess()` rejects the `User` alias outright.
But resolving aliases *without* touching `ModuleService` would make it reachable: `User` would pass
the gate and then skip `assertSelfOrAdmin()` and the `show_on_employees` filter, letting a non-admin
read arbitrary user records. So the module name is normalised in `ModuleService` too, in the same
change, rather than introducing that regression.

## Motivation and Context

Any integration written against 8.10.1 or earlier that used the documented alias names breaks on
upgrade to 8.10.2, with an error that points at permissions rather than at name resolution — a
misleading trail for anyone debugging it.

## How To Test This

Obtain an OAuth2 token as an **admin** user, then:

```bash
# Fails on 8.10.2, succeeds with this PR
curl -H "Authorization: Bearer $TOKEN" -H 'Accept: application/vnd.api+json' \
     'https://<host>/Api/V8/module/Contracts?page[size]=1'

# Works either way, for comparison
curl -H "Authorization: Bearer $TOKEN" -H 'Accept: application/vnd.api+json' \
     'https://<host>/Api/V8/module/AOS_Contracts?page[size]=1'
```

Both must now return the same records. Note the JSON:API `type` in the response is built from
`$bean->getObjectName()`, so it stays `AOS_Contracts` in both cases: response payloads are
unchanged by this PR.

Regression checks worth running:

1. **ACL is still enforced through the alias.** As a non-admin, a request for an admin-only module
   under its alias (`ACLRole`) must still be refused, exactly as `ACLRoles` is.
2. **Users/Employees restrictions still apply through the alias.** As a non-admin, reading another
   user's record via `GET /Api/V8/module/User/<other-id>` must be denied, and
   `GET /Api/V8/module/User/<own-id>` allowed — same as with `Users`.
3. **Unknown modules are still rejected**, e.g. `GET /Api/V8/module/NotAThing`.

Verified locally against 8.10.2 with a real database, admin plus a non-admin user:
aliases resolve correctly (`Contracts` -> `AOS_Contracts`, `Account` -> `Accounts`,
`Accounts` -> `Accounts` untouched, unknown names passed through); the gate accepts aliases for
admin; a non-admin is still refused on admin-only modules under both alias and real name; and
`assertSelfOrAdmin()` receives the canonical `Users` and still denies cross-user reads while
allowing self.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.