### PR TITLE
Add V8 API endpoint to download Note and Document files

### DIFF
--- a/public/legacy/Api/V8/Config/routes.php
+++ b/public/legacy/Api/V8/Config/routes.php
@@ -64,6 +64,13 @@ $app->group('', function () use ($app) {
             ->add($paramsMiddlewareFactory->bind(Param\GetModuleParams::class));
 
         /**
+         * Get the file attached to a module record
+         */
+        $app
+            ->get('/module/{moduleName}/{id}/file', 'Api\V8\Controller\ModuleController:getModuleRecordFile')
+            ->add($paramsMiddlewareFactory->bind(Param\GetModuleFileParams::class));
+
+        /**
          * Create a module record
          */
         $app

--- a/public/legacy/Api/V8/Config/services/params.php
+++ b/public/legacy/Api/V8/Config/services/params.php
@@ -37,6 +37,12 @@ return CustomLoader::mergeCustomArray([
             $container->get(BeanManager::class)
         );
     },
+    Param\GetModuleFileParams::class => function (Container $container) {
+        return new Param\GetModuleFileParams(
+            $container->get(ValidatorFactory::class),
+            $container->get(BeanManager::class)
+        );
+    },
     Param\CreateModuleParams::class => function (Container $container) {
         return new Param\CreateModuleParams(
             $container->get(ValidatorFactory::class),

--- a/public/legacy/Api/V8/Controller/ModuleController.php
+++ b/public/legacy/Api/V8/Controller/ModuleController.php
@@ -3,6 +3,7 @@ namespace Api\V8\Controller;
 
 use Api\V8\Param\CreateModuleParams;
 use Api\V8\Param\DeleteModuleParams;
+use Api\V8\Param\GetModuleFileParams;
 use Api\V8\Param\GetModuleParams;
 use Api\V8\Param\GetModulesParams;
 use Api\V8\Param\UpdateModuleParams;
@@ -37,6 +38,25 @@ class ModuleController extends BaseController
     {
         try {
             $jsonResponse = $this->moduleService->getRecord($params, $request->getUri()->getPath());
+
+            return $this->generateResponse($response, $jsonResponse, 200);
+        } catch (\Exception $exception) {
+            return $this->generateErrorResponse($response, $exception, 400);
+        }
+    }
+
+    /**
+     * @param Request $request
+     * @param Response $response
+     * @param array $args
+     * @param GetModuleFileParams $params
+     *
+     * @return Response
+     */
+    public function getModuleRecordFile(Request $request, Response $response, array $args, GetModuleFileParams $params)
+    {
+        try {
+            $jsonResponse = $this->moduleService->getRecordFile($params);
 
             return $this->generateResponse($response, $jsonResponse, 200);
         } catch (\Exception $exception) {

--- a/public/legacy/Api/V8/Param/GetModuleFileParams.php
+++ b/public/legacy/Api/V8/Param/GetModuleFileParams.php
@@ -1,0 +1,39 @@
+<?php
+namespace Api\V8\Param;
+
+use Api\V8\Param\Options as ParamOption;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+#[\AllowDynamicProperties]
+class GetModuleFileParams extends BaseParam implements ModuleAwareParamInterface
+{
+    /**
+     * @return string
+     */
+    public function getModuleName()
+    {
+        return $this->parameters['moduleName'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->parameters['id'];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configureParameters(OptionsResolver $resolver)
+    {
+        $this->setOptions(
+            $resolver,
+            [
+                ParamOption\ModuleName::class,
+                ParamOption\Id::class,
+            ]
+        );
+    }
+}

--- a/public/legacy/Api/V8/Service/ModuleService.php
+++ b/public/legacy/Api/V8/Service/ModuleService.php
@@ -7,6 +7,7 @@ use Api\V8\BeanDecorator\BeanManager;
 use Api\V8\JsonApi\Helper\AttributeObjectHelper;
 use Api\V8\JsonApi\Helper\PaginationObjectHelper;
 use Api\V8\JsonApi\Helper\RelationshipObjectHelper;
+use Api\V8\JsonApi\Response\AttributeResponse;
 use Api\V8\JsonApi\Response\DataResponse;
 use Api\V8\JsonApi\Response\DocumentResponse;
 use Api\V8\JsonApi\Response\MetaResponse;
@@ -14,6 +15,7 @@ use Api\V8\Param\CreateModuleParams;
 use BeanFactory;
 use DocumentRevision;
 use Api\V8\Param\DeleteModuleParams;
+use Api\V8\Param\GetModuleFileParams;
 use Api\V8\Param\GetModuleParams;
 use Api\V8\Param\GetModulesParams;
 use Api\V8\Param\UpdateModuleParams;
@@ -89,6 +91,72 @@ class ModuleService
         }
 
         $dataResponse = $this->getDataResponse($bean, $fields, $path);
+
+        $response = new DocumentResponse();
+        $response->setData($dataResponse);
+
+        return $response;
+    }
+
+    /**
+     * Returns the file attached to a record, base64 encoded — the counterpart
+     * of the upload support in createRecord/updateRecord (filecontents
+     * attribute). Notes store their file at upload/{note_id} (addFileToNote),
+     * Documents at upload/{document_revision_id} (addFileToDocument).
+     *
+     * @param GetModuleFileParams $params
+     * @return DocumentResponse
+     * @throws AccessDeniedException
+     * @throws InvalidArgumentException When the module has no file support or the record has no file.
+     * @throws Exception When the stored file cannot be read.
+     */
+    public function getRecordFile(GetModuleFileParams $params)
+    {
+        $module = $params->getModuleName();
+        $bean = $this->beanManager->getBeanSafe($module, $params->getId());
+
+        $this->assertSelfOrAdmin($module, $bean->id);
+        if (!$bean->ACLAccess('view')) {
+            throw new AccessDeniedException();
+        }
+
+        $filename = (string) $bean->filename;
+        $mimeType = (string) $bean->file_mime_type;
+
+        if ($module === 'Notes') {
+            $fileId = $bean->id;
+        } elseif ($module === 'Documents') {
+            $fileId = (string) $bean->document_revision_id;
+            $revision = $fileId !== '' ? BeanFactory::getBean('DocumentRevisions', $fileId) : null;
+            if ($revision !== null && !empty($revision->id)) {
+                $filename = (string) ($revision->filename ?: $filename);
+                $mimeType = (string) ($revision->file_mime_type ?: $mimeType);
+            }
+        } else {
+            throw new InvalidArgumentException(
+                sprintf('Module %s does not support file attachments', $module)
+            );
+        }
+
+        $filePath = 'upload/' . $fileId;
+        if ($fileId === '' || $filename === '' || !file_exists($filePath)) {
+            throw new InvalidArgumentException(
+                sprintf('Record %s in module %s has no attached file', $bean->id, $module)
+            );
+        }
+
+        $contents = file_get_contents($filePath);
+        if ($contents === false) {
+            LoggerManager::getLogger()->error('getRecordFile: unable to read ' . $filePath);
+            throw new Exception('Attached file could not be read');
+        }
+
+        $dataResponse = new DataResponse($bean->getObjectName(), $bean->id);
+        $dataResponse->setAttributes(new AttributeResponse([
+            'filename' => $filename,
+            'file_mime_type' => $mimeType,
+            'filecontents' => base64_encode($contents),
+        ]));
 
         $response = new DocumentResponse();
         $response->setData($dataResponse);

--- a/public/legacy/Api/docs/swagger/swagger.json
+++ b/public/legacy/Api/docs/swagger/swagger.json
@@ -113,6 +113,50 @@
         ]
       }
     },
+    "/module/{moduleName}/{id}/file": {
+      "get": {
+        "tags": [
+          "Module"
+        ],
+        "description": "Returns the file attached to a bean, base64 encoded. Supported for Notes (attachment) and Documents (latest revision) - the counterpart of creating a record with the filecontents attribute.",
+        "parameters": [
+          {
+            "name": "moduleName",
+            "in": "path",
+            "description": "Name of the module (Notes or Documents)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Notes"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the module",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "b13a39f8-1c24-c5d0-ba0d-5ab123d6e899"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "BAD REQUEST"
+          }
+        },
+        "security": [
+          {
+            "oauth2": []
+          }
+        ]
+      }
+    },
     "/module/{module}": {
       "get": {
         "tags": [

--- a/public/legacy/tests/api/V8/GetModuleFileCest.php
+++ b/public/legacy/tests/api/V8/GetModuleFileCest.php
@@ -1,0 +1,108 @@
+<?php
+namespace Test\Api\V8;
+
+use ApiTester;
+
+#[\AllowDynamicProperties]
+class GetModuleFileCest
+{
+    /**
+     * @param ApiTester $I
+     *
+     * @throws \Codeception\Exception\ModuleException
+     */
+    public function _before(ApiTester $I)
+    {
+        $I->login();
+    }
+
+    /**
+     * @param ApiTester $I
+     *
+     * @throws \Exception
+     */
+    public function shouldReturnNoteAttachment(ApiTester $I)
+    {
+        $fileContents = 'SuiteCRM V8 API file download test';
+
+        $I->sendPOST($I->getInstanceURL() . '/Api/V8/module', [
+            'data' => [
+                'type' => 'Notes',
+                'attributes' => [
+                    'name' => 'Note with attachment',
+                    'filename' => 'test.txt',
+                    'filecontents' => base64_encode($fileContents),
+                ],
+            ],
+        ]);
+        $I->seeResponseCodeIs(201);
+        $I->seeResponseIsJson();
+        $id = $I->grabDataFromResponseByJsonPath('$.data.id')[0];
+
+        $I->sendGET($I->getInstanceURL() . '/Api/V8/module/Notes/' . $id . '/file');
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+        $I->canSeeResponseContainsJson([
+            'id' => $id,
+        ]);
+
+        $attributes = $I->grabDataFromResponseByJsonPath('$.data.attributes')[0];
+        $I->assertEquals('test.txt', $attributes['filename']);
+        $I->assertEquals($fileContents, base64_decode($attributes['filecontents']));
+
+        @unlink('upload/' . $id);
+        $I->deleteBean('notes', $id);
+    }
+
+    /**
+     * @param ApiTester $I
+     *
+     * @throws \Exception
+     */
+    public function shouldNotWorkWithoutAttachedFile(ApiTester $I)
+    {
+        $I->sendPOST($I->getInstanceURL() . '/Api/V8/module', [
+            'data' => [
+                'type' => 'Notes',
+                'attributes' => [
+                    'name' => 'Note without attachment',
+                ],
+            ],
+        ]);
+        $I->seeResponseCodeIs(201);
+        $id = $I->grabDataFromResponseByJsonPath('$.data.id')[0];
+
+        $I->sendGET($I->getInstanceURL() . '/Api/V8/module/Notes/' . $id . '/file');
+        $I->seeResponseCodeIs(400);
+        $I->seeResponseIsJson();
+        $I->canSeeResponseContainsJson([
+            'errors' => [
+                'status' => 400,
+            ],
+        ]);
+
+        $I->deleteBean('notes', $id);
+    }
+
+    /**
+     * @param ApiTester $I
+     *
+     * @throws \Exception
+     */
+    public function shouldNotWorkForUnsupportedModule(ApiTester $I)
+    {
+        $id = $I->createAccount();
+
+        $I->sendGET($I->getInstanceURL() . '/Api/V8/module/Accounts/' . $id . '/file');
+        $I->seeResponseCodeIs(400);
+        $I->seeResponseIsJson();
+        $I->canSeeResponseContainsJson([
+            'errors' => [
+                'status' => 400,
+                'detail' => 'Module Accounts does not support file attachments',
+            ],
+        ]);
+
+        $I->deleteBean('accounts', $id);
+    }
+}


### PR DESCRIPTION
## Description

Adds a V8 API endpoint to download the file attached to a record — the read counterpart of the existing `filecontents` upload support in create/update:

```
GET /Api/V8/module/{moduleName}/{id}/file
```

Returns a JSON:API document with `filename`, `file_mime_type`, and base64 `filecontents`, symmetric with what record creation accepts. Supported modules mirror the upload side exactly:

- **Notes** — attachment stored at `upload/{note_id}` (see `addFileToNote`)
- **Documents** — latest revision stored at `upload/{document_revision_id}` (see `addFileToDocument`); filename/mime type fall back to the DocumentRevision bean

Other modules return a 400 with a clear message, as do records with no attached file. The route runs inside the existing OAuth2 `ResourceServerMiddleware` (401 without a token) and enforces `ACLAccess('view')` on the bean before any filesystem access. The bean lookup happens before the file read, and ids are server-generated GUIDs, so arbitrary `{id}` values never reach the filesystem.

Includes the swagger definition and Codeception API functional tests (`GetModuleFileCest`: round-trip, no-file 400, unsupported-module 400).

Closes #1001

## Motivation and Context

The V8 API can create a Note or Document *with* a file (`filecontents` attribute) but has no endpoint to read the file back — `GET /Api/V8/module/Notes/{id}` returns metadata only, so API integrations are write-only for attachments. This is a long-standing community ask (see issue #1001 for forum references). SuiteCRM 7's `entryPoint=download` fallback is session-authenticated rather than OAuth2 and is not a substitute for API clients.

## How To Test This

1. Create a Note with an attachment via the API:
   ```
   POST /Api/V8/module
   {"data":{"type":"Notes","attributes":{"name":"test","filename":"test.txt","filecontents":"<base64>"}}}
   ```
2. Download it back:
   ```
   GET /Api/V8/module/Notes/{id}/file
   ```
   Expect 200 with `filename`, `file_mime_type`, and base64 `filecontents` matching the upload.
3. A Note without a file and a module without file support (e.g. Accounts) both return 400 with a descriptive error; requests without a Bearer token return 401.
4. Same round-trip works for Documents (`document_name`, `revision`, `filename`, `filecontents` on create).

Manually verified against a SuiteCRM 8.8.0 instance (Notes and Documents round-trips, error cases, auth enforcement); automated coverage in `public/legacy/tests/api/V8/GetModuleFileCest.php`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
