### PR TITLE
Fix #605 - Quotes module - download import file template option under…

### DIFF
--- a/public/legacy/.codecov.yml
+++ b/public/legacy/.codecov.yml
@@ -54,7 +54,7 @@ ignore:
   - "modules/AOS_PDF_Templates/PDF_Lib/.*"
   - "Zend/.*"
   - "modules/Users/authentication/SAML2Authenticate/lib/.*"
-  - "install/demoData.en_us.php"
+  - "install/seed_data/demoData.en_us.php"
   - "include/tcpdf/.*"
   - "modules/AOR_Charts/lib/.*"
   # The old lowercase v8 API is deprecated/unsupported and the CI doesn't run the tests for it. The new API uses an upper-case V.

--- a/public/legacy/.php_cs.dist
+++ b/public/legacy/.php_cs.dist
@@ -31,7 +31,7 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('modules/AOS_PDF_Templates/PDF_Lib')
     ->exclude('modules/Users/authentication/SAML2Authenticate/lib')
     ->exclude('modules/AOR_Charts/lib')
-    ->exclude('install/demoData.en_us.php')
+    ->exclude('install/seed_data/demoData.en_us.php')
     ->exclude('include/SugarObjects/templates')
     ->in($paths->getProjectPath());
 

--- a/public/legacy/codacy.yml
+++ b/public/legacy/codacy.yml
@@ -16,6 +16,6 @@ exclude_paths:
   - 'modules/AOS_PDF_Templates/PDF_Lib/**'
   - 'Zend/**'
   - 'modules/Users/authentication/SAML2Authenticate/lib/**'
-  - 'install/demoData.en_us.php*'
+  - 'install/seed_data/demoData.en_us.php*'
   - 'include/tcpdf/**'
   - 'modules/AOR_Charts/lib/**'

--- a/public/legacy/codeception.dist.yml
+++ b/public/legacy/codeception.dist.yml
@@ -44,7 +44,7 @@ coverage:
     - include/parsecsv.lib.php
     - modules/AOS_PDF_Templates/PDF_Lib/*
     - modules/Users/authentication/SAML2Authenticate/lib/*
-    - install/demoData.en_us.php
+    - install/seed_data/demoData.en_us.php
     - include/tcpdf/*
     - modules/AOR_Charts/lib/*
 params:

--- a/public/legacy/include/export_utils.php
+++ b/public/legacy/include/export_utils.php
@@ -5,7 +5,7 @@
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
  *
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
- * Copyright (C) 2011 - 2021 SalesAgility Ltd.
+ * Copyright (C) 2011 - 2026 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -601,7 +601,7 @@ function generateSearchWhere($module, $query)
      }
 
      //include the file that defines $sugar_demodata
-     include('install/demoData.en_us.php');
+     include('install/seed_data/demoData.en_us.php');
 
      $person_bean = false;
      if (isset($focus->first_name)) {


### PR DESCRIPTION
… import option not working

## Description
Fixes #605 
The `demoData.en_us.php` file was moved in 4b713e8 but references to it were not updated.
This fix updates the references in `export_utils.php` as well as associated references in CI files.

## Motivation and Context
When attempting to download the sample import file for **any** module* (issue #605 mentions Quotes but it happens on all modules) when there are no records for that type in the DB, you get a 500 error due to a reference to the old file location.

## How To Test This
For a module which you have no rows in the DB:

1. Click on **Import module**, e.g. **Import Accounts**
2. Click on **Download Import File Template** link.

Expected results:
- sample file downloaded

Actual results:
- blank screen and FATAL error in PHP logs.

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [ x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
