### PR TITLE
Fix #958 - Products and Services purchased shows 1 for a newly create…

### DIFF
--- a/public/legacy/include/portability/Subpanels/SubpanelCustomQueryPort.php
+++ b/public/legacy/include/portability/Subpanels/SubpanelCustomQueryPort.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * SuiteCRM is a customer relationship management program developed by SalesAgility Ltd.
- * Copyright (C) 2021 SalesAgility Ltd.
+ * Copyright (C) 2021 - 2026 SalesAgility Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License version 3 as published by the
@@ -212,6 +212,9 @@ class SubpanelCustomQueryPort
             'where' => '',
             'order_by' => '',
         ];
+
+        // Normalize whitespace in query
+        $query = trim(preg_replace('/\s+/', ' ', $query));
 
         $fromPos = stripos($query, ' FROM ');
         if ($fromPos !== false) {


### PR DESCRIPTION
…d Account

## Description
Fixes #958.

Normalizes whitespace in queries passed to `decomposeQueryString()`. The query for the "Products and Services Purchased" relationship on the Account details page subpanel uses tabs but `decomposeQueryString()` was expecting spaces around the `FROM` keyword, resulting in an incorrect query. Similar to the code in `SubPanelRowCounter::selectQueryToCountQuery()`.

## Motivation and Context
When viewing a newly created Account it would show that there was 1 "Products and Services Purchased" in the Relationships panel, when clicking on this is correctly showed there were none.

## How To Test This
1. Create an Account
2. Click on the name of the newly created account
3. In the "Relationships panel" view the number of relationships found for "Products and Services Purchased"
4. Click on "Products and Services Purchased" to see the relationships

Expected results:
- The number of relationships is 0
- When clicking on "Products and Services Purchased" is shows there are none

Actual results:
- The number of relationships is 1
- When clicking on "Products and Services Purchased" is shows there are none


## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [ x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
