### PR TITLE
Fix #1011 - Decode saved search JSON without HTML encoding

### DIFF
--- a/public/legacy/modules/SavedSearch/SavedSearch.php
+++ b/public/legacy/modules/SavedSearch/SavedSearch.php
@@ -587,7 +587,7 @@ class SavedSearch extends SugarBean
 
     public function retrieveSavedSearch($id)
     {
-        parent::retrieve($id);
+        parent::retrieve($id, false);
         $this->contents = $this->decodeContents($this->contents);
     }
 

--- a/public/legacy/tests/unit/phpunit/modules/SavedSearch/SavedSearchTest.php
+++ b/public/legacy/tests/unit/phpunit/modules/SavedSearch/SavedSearchTest.php
@@ -46,6 +46,35 @@ class SavedSearchTest extends SuitePHPUnitFrameworkTestCase
         self::assertGreaterThan(0, strlen((string) $result));
     }
 
+    public function testRetrieveSavedSearchDecodesJsonContents(): void
+    {
+        global $current_user;
+
+        $expected = [
+            'search_module' => 'Accounts',
+            'name_advanced' => 'Acme',
+            'orderBy' => 'name',
+            'sortOrder' => 'ASC',
+            'advanced' => true,
+        ];
+        $savedSearch = BeanFactory::newBean('SavedSearch');
+        $savedSearch->name = 'SavedSearch JSON retrieval test';
+        $savedSearch->assigned_user_id = $current_user->id;
+        $savedSearch->contents = json_encode($expected, JSON_THROW_ON_ERROR);
+
+        try {
+            $id = $savedSearch->save();
+            $retrieved = BeanFactory::newBean('SavedSearch');
+            $retrieved->retrieveSavedSearch($id);
+
+            self::assertSame($expected, $retrieved->contents);
+        } finally {
+            if (!empty($savedSearch->id)) {
+                $savedSearch->mark_deleted($savedSearch->id);
+            }
+        }
+    }
+
     public function handleSaveAndRetrieveSavedSearch($id): void
     {
         $savedSearch = BeanFactory::newBean('SavedSearch');


### PR DESCRIPTION
## Description

Fixes #1011.

`SavedSearch::retrieveSavedSearch()` now retrieves the structured `contents` field without SugarBean HTML encoding before passing it to `decodeContents()`.

A regression test stores a JSON-backed saved search, retrieves it through the affected method, verifies the decoded array, and removes the test record in a `finally` block.

## Motivation and Context

Saved-search contents are stored as JSON after the security changes associated with GHSA-mhq2-277m-6w24. The default `$encode = true` behavior of `SugarBean::retrieve()` converts JSON quotes to `&quot;`. The subsequent JSON decode fails, so selecting an entry from **My Filters** loses `search_module` and redirects the user to the dashboard.

This change preserves the secure JSON storage and the restricted legacy deserialization fallback. It only prevents display-oriented HTML encoding from being applied to the structured payload before decoding. `returnSavedSearchContents()` already reads the same field with encoding disabled.

## How To Test This

Automated regression:

1. Run `SavedSearchTest` in the legacy PHPUnit suite.
2. Confirm `testRetrieveSavedSearchDecodesJsonContents` passes.

Manual verification:

1. Open a legacy module list view, such as Accounts.
2. Save search criteria through **My Filters**.
3. Select the saved filter.
4. Confirm the filtered module list opens instead of the dashboard.

Local validation completed:

- PHP lint on both changed files.
- `git diff --check`.
- Application-level legacy save/select/delete round trip on SuiteCRM 8.10.2.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **How to Contribute** guidelines.