### PR TITLE
Fix #1013 - Unable to add browser spell check to TinyMCE editor

### DIFF
--- a/public/legacy/include/SugarTinyMCE.php
+++ b/public/legacy/include/SugarTinyMCE.php
@@ -91,6 +91,7 @@ class SugarTinyMCE
         'entities' => '160,nbsp,38,amp,60,lt,62,gt,34,quot,39,apos,162,cent,163,pound,165,yen,8364,euro,169,copy,174,reg,8482,trade',
         'forced_root_block' => false,
         'fix_list_elements' => false,
+        'browser_spellcheck' => false,
     ];
 
     /**
@@ -304,7 +305,7 @@ eoq;
     private function overloadDefaultConfigs()
     {
         if (file_exists($this->customDefaultConfigFile)) {
-            require_once($this->customDefaultConfigFile);
+            require($this->customDefaultConfigFile);
 
             if (!isset($defaultConfig)) {
                 return;


### PR DESCRIPTION
## Description
Fixes #1013.
Allows custom overriding of `browser_spellcheck` configuration in TinyMCE.
Adds it as an allowable override, defaulting to `false` to preserve existing behaviour.
This can be overridden in `public/legacy/custom/include/tinyMCEDefaultConfig.php`.
Fixed issue where custom configuration file was not included correctly.

## Motivation and Context
This allows admins to specify that TinyMCE should use the browser spell checker by providing a custom configuration file. It also fixes an issue where the custom configuration file was not included correctly.

## How To Test This
1. Add a custom TinyMCE configuration override file to `public/legacy/custom/include/tinyMCEDefaultConfig.php` which allows browser spellcheck.
2. Create a new Email
3. Misspell a word in the editor

Expected results
- Misspelled word underlined in red by browser spell check

Actual results
- Misspelled word is not underlined

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [ x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
